### PR TITLE
docs: README redesign with centered header, logo, i18n + runnable demo; switch license to MIT

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,26 @@
-# Private distribution notice
+# MIT License
 
-Copyright (c) 2026 repository owner. All rights reserved.
+Copyright (c) 2026 Ableton MCP Beyond contributors
 
-This repository and its release artifacts are private, unpublished software.
-No permission is granted to publish, redistribute, sublicense, or use the
-Ableton or third-party trademarks. Local installation and evaluation by the
-repository owner and explicitly authorized operators is permitted.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-No warranty or fitness claim is made. A different public or commercial license
-requires an explicit owner decision and a separately reviewed release.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Ableton Live is a trademark of Ableton AG. This project is not affiliated
+with, endorsed by, or sponsored by Ableton AG.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,92 @@
+<p align="center">
+  <img src="docs/assets/logo.svg" width="100" alt="Ableton MCP Beyond ロゴ" />
+</p>
+
+<h1 align="center">Ableton MCP Beyond</h1>
+
+<p align="center">
+  安全性第一の Ableton Live 12 MCP コントロール ——<br/>
+  76 のツール、認証済みループバックブリッジ、規格準拠のオーディオ解析。
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · 日本語
+</p>
+
+<p align="center">
+  <a href="https://github.com/user1303836/ableton-mcp-beyond/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/user1303836/ableton-mcp-beyond/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="MIT ライセンス" /></a>
+  <a href="apps/mcp-server/package.json"><img src="https://img.shields.io/badge/node-22%20%7C%2024%20%7C%2025-339933?style=flat-square" alt="Node 22 | 24 | 25" /></a>
+  <a href="https://modelcontextprotocol.io/specification/2025-11-25"><img src="https://img.shields.io/badge/MCP-2025--11--25-blue?style=flat-square" alt="MCP プロトコル 2025-11-25" /></a>
+  <a href="docs/SUPPORT_MATRIX.md"><img src="https://img.shields.io/badge/Ableton%20Live-12-555555?style=flat-square" alt="Ableton Live 12" /></a>
+</p>
+
+---
+
+**決して推測で動かず、あなたの Set を壊さない MCP ホスト。**
+
+- **ディープな Live 制御** —— トランスポート、Session + Arrangement、クリップ、MIDI ノート、ミキサー、オートメーション、ルーティング、録音、プロジェクト、サブスクリプション。
+- **デバイスを使いこなす** —— rack/chain/pad/macro の再帰的ディスカバリ、ガード付きパラメータ編集、Browser の検索とロード。
+- **オーディオインテリジェンス** —— ITU-R BS.1770-5 / EBU R128 ラウドネス、検証済みトゥルーピーク、リファレンスミックス比較。Live なしで動作。
+- **同意ベースのキャプチャ** —— 1 つのクリップをリサンプリングし、内部で解析、すべての痕跡を削除。ウォッチドッグと緊急停止を内蔵。
+- **リアルタイム制御** —— トークンで隔離された UDP/OSC/XY チャンネル。書き込み検証と独立した緊急停止付き。
+- **ガイド付きジャーニー** —— `plan_user_journey` が「ローファイなビートを作って」を、順序立て・確認可能・ケイパビリティ対応のプランに変換。
+
+## クイックスタート
+
+Node.js 22 / 24 / 25 が必要です。ブリッジには Ableton Live 12 が必要ですが、ホスト・テスト・デモは Live なしで動きます。
+
+```sh
+cd apps/mcp-server
+npm ci && npm run build
+npm run demo      # 実際の MCP セッション。Live 不要
+npm test          # フルテストスイート
+```
+
+MCP クライアントをサーバーに向け、Live を制御する場合はブリッジを設定して Remote Script をインストールします:
+
+```sh
+npm run setup -- --output /abs/path/client-config.json
+npm run setup -- --output /abs/path/bridge-config.json \
+  --bridge-host 127.0.0.1 --bridge-port 9000 \
+  --secret-file /abs/path/bridge.secret
+node dist/src/install-remote-script.js --destination '/abs/.../Remote Scripts/AbletonMcpBridge' --dry-run
+```
+
+Live を再起動し、検証します: `npm run diagnostics -- --config /abs/path/bridge-config.json`。
+完全な手順: [docs/USER_GUIDE.md](docs/USER_GUIDE.md)(英語)。
+
+## 安全モデル
+
+すべての変更は **検出 → プレビュー → 確認 → 適用 → 検証 → アンドゥ** の手順に従います。冪等キー、エポックフェンシング、実行台帳により、応答喪失時も安全に照合でき、恣意的な削除は拒否されます。明示的なブリッジ設定がない限り、サーバーはフェイルクローズド —— Live を読むことも触れることもありません。詳細: [docs/LIVE_SAFETY.md](docs/LIVE_SAFETY.md)(英語)。
+
+## 互換性
+
+| 環境 | ステータス |
+|---|---|
+| Node.js 22 / 24 / 25 | サポート(CI テスト済み) |
+| macOS + Live 12 | 12.4.5b8 beta で検証済み([エビデンス](docs/evidence/)) |
+| Windows ホスト | CI テスト済み。Windows 11 + Live は未認証 |
+| Linux / Live 11 以前 | 非対応 |
+
+ケイパビリティは接続時にネゴシエートされるため、エージェントは常にその Live 環境で何ができるかを正確に把握できます。完全なマトリクス: [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md)(英語)。
+
+## ドキュメント
+
+以下のドキュメントはすべて英語です。
+
+| ドキュメント | 内容 |
+|---|---|
+| [USER_GUIDE](docs/USER_GUIDE.md) | ツール一覧、変更ワークフロー、リソース、プロンプト |
+| [LIVE_SAFETY](docs/LIVE_SAFETY.md) | 実機 Live の安全境界 |
+| [OPERATIONS](docs/OPERATIONS.md) / [RECOVERY](docs/RECOVERY.md) | 運用監視、障害対応、不確定状態からの回復 |
+| [AUDIO_INTELLIGENCE](docs/AUDIO_INTELLIGENCE.md) | DSP 規格、キャプチャ同意、プライバシー制限 |
+| [USER_JOURNEYS](docs/USER_JOURNEYS.md) | 5 つのガイド付き作曲ワークフロー |
+| [REALTIME_CONTROL](docs/REALTIME_CONTROL.md) | アームされた UDP/OSC/XY コントロールプレーン |
+| [CAPABILITY_MATRIX](docs/CAPABILITY_MATRIX.md) | ツールごとのケイパビリティと操作要件 |
+| [DELIVERY](docs/DELIVERY.md) | パッケージ成果物のインストール、アップグレード、ロールバック、アンインストール |
+| [IMPLEMENTATION_STATUS](docs/IMPLEMENTATION_STATUS.md) | 検証済みの内容と現在の制限 |
+
+## ライセンス
+
+[MIT ライセンス](LICENSE.md)のオープンソースです。Ableton Live は Ableton AG の商標です。本プロジェクトは Ableton AG とは提携しておらず、認められたものでもありません。

--- a/README.md
+++ b/README.md
@@ -1,152 +1,179 @@
 # Ableton MCP Beyond
 
-A safety-first MCP host for bounded Ableton Live integration.
+**Give your AI agent real, safety-first control of Ableton Live 12 — Session and
+Arrangement, devices, mixer, browser, recording — plus standards-based audio
+analysis, all over the Model Context Protocol.**
 
-The server speaks newline-delimited JSON-RPC over stdio. Without `--config`,
-it uses `UnavailableLiveAdapter`; no Live state is read or changed. With an
-explicit validated version-2 configuration, the packaged CLI connects to the
-loopback `AbletonMcpBridge` over the authenticated `ableton-loopback/v1`
-transport.
+![Node 22 | 24 | 25](https://img.shields.io/badge/node-22%20%7C%2024%20%7C%2025-339933)
+![MCP 2025-11-25](https://img.shields.io/badge/MCP-2025--11--25-blue)
+![Ableton Live 12](https://img.shields.io/badge/Ableton%20Live-12-5b2ee5)
+
+A Node.js MCP host (76 tools, stdio JSON-RPC) that talks to Live through an
+authenticated, HMAC-sealed loopback bridge and a Python Remote Script
+(`AbletonMcpBridge`). Developed and verified against **Live 12.4.5b8 (beta)**.
+Without an explicit bridge configuration it is **fail-closed**: it never reads
+or touches your Set.
+
+## See it work — no Live required
+
+```sh
+cd apps/mcp-server
+npm ci && npm run build
+npm run demo
+```
+
+This drives a real MCP session against the server: handshake, full tool
+catalog, fail-closed status, a live `audio_analyze` run on a synthesized tone,
+and a generated beat-making plan.
+
+<details>
+<summary><b>Actual demo output</b></summary>
+
+```text
+▶ initialize (MCP protocol 2025-11-25)
+  server: {"name":"ableton-mcp-host","version":"1.0.0"}
+
+▶ tools/list
+  tools exposed: 76
+  server_status, capabilities, plan_user_journey, audio_analyze, … live_undo, live_recovery_finalize
+
+▶ server_status + live_status (no Live configured → fail-closed)
+  server_status: {"host":"ready","live":{"connected":false,"adapter":"unavailable", … }}
+  live_status.adapter: "unavailable"
+
+▶ audio_analyze: 2 s 440 Hz sine @ 48 kHz → BS.1770-5 loudness, true peak, spectra
+  peak / rms: "-6.02 dBFS / -9.03 dBFS"
+  BS.1770-5 integrated loudness: "-9.71 LUFS (standardsCompliant: true)"
+  BS.1770-5 Annex 2 true peak: "-6.008 dBTP (ITU-R BS.1770-5 Annex 2 order-48 four-phase FIR)"
+
+▶ plan_user_journey: beat-making plan
+  journey: "create-beat-or-song"
+  stages: ["discover","draft","preview-create","apply-create","arrange",
+           "arrange-edit","audition","revise","final-readback"]
+
+▶ done — no Live instance was read or changed
+```
+
+</details>
 
 ## Quick start
 
-Requirements: Node.js 22, 24, or 25 (all three are exercised in CI).
+**Requirements:** Node.js 22, 24, or 25 (all exercised in CI). Ableton Live 12
+for the bridge; the host, tests, and demo run without it.
 
 ```sh
 cd apps/mcp-server
 npm ci
-npm test
-npm start
+npm test          # full build + test suite
+npm start         # serve MCP over stdio
 ```
 
-The MCP executable is `dist/src/cli.js`. It accepts one JSON-RPC message per
-line on stdin and writes only JSON-RPC responses to stdout. Initialize with
-protocol version `2025-11-25`, then send `notifications/initialized`.
-
-For the client-facing tool list and mutation sequence, see
-[`docs/USER_GUIDE.md`](docs/USER_GUIDE.md). For supervision and failure
-handling, see [`docs/OPERATIONS.md`](docs/OPERATIONS.md) and
-[`docs/RECOVERY.md`](docs/RECOVERY.md).
-
-The source-controlled operation contract is
-[`protocol/ableton-live-v1.operations.json`](protocol/ableton-live-v1.operations.json).
-The bridge negotiates its canonical SHA-256 before serving Live operations. The current host surface includes bounded discovery; guarded Session and
-Arrangement lifecycles; transport, MIDI, mixer, automation, devices/racks,
-Browser, routing, recording, projects, subscriptions, realtime control;
-standards audio/reference intelligence; and consent-bound real-Live Resampling
-capture. The Python mapper supports bounded,
-epoch-scoped discovery for the observed hierarchy, including regular/group,
-return and main tracks, scenes, parent-scoped clip slots and clips, notes,
-locators, devices, parameters, selection, routing choices, and Session
-playback. Unsupported or unobserved Live shapes remain unavailable.
-
-Build a host-only client configuration:
+**1. Point your MCP client at the server.** Generate a client config:
 
 ```sh
-npm run build
 npm run setup -- --output /absolute/path/client-config.json
 ```
 
-To enable the bridge, create a strong owner-only secret separately, then
-generate a version-2 configuration:
+**2. Connect Live.** Create a strong owner-only secret, then generate a
+bridge configuration:
 
 ```sh
 npm run setup -- --output /absolute/path/bridge-config.json \
   --bridge-host 127.0.0.1 --bridge-port 9000 \
-  --realtime-port 9001 \
   --secret-file /absolute/path/bridge.secret --bridge-timeout 5000
 ```
 
-The generated version-2 client entry includes `--config
-/absolute/path/bridge-config.json`; the secret remains in its separate
-owner-only file and is never placed in client arguments. `--realtime-port` is
-optional; when present it enables only the separately armed loopback control
-plane documented in [`docs/REALTIME_CONTROL.md`](docs/REALTIME_CONTROL.md).
-
-The CLI loads a bridge only when `--config /absolute/path/bridge-config.json`
-is supplied. Configuration, secret, and Remote Script installation are never
-selected from JSON-RPC arguments or client metadata.
-
-For an installed artifact, run `npm run diagnostics -- --config
-/absolute/path/bridge-config.json`. Diagnostics validate the package manifest's
-raw asset hashes and canonical registry hash, then perform authenticated,
-bounded Set, scene, track, child clip-slot, and Session-playback discovery.
-They report adapter operations separately from capabilities. `fake-live`,
-simulator, unavailable, and unknown provenance remain non-passing evidence for
-`liveConnected`, real Live state, audible state, or restoration.
-
-Private installed artifacts use the receipt-driven lifecycle CLI for exact
-install, manual activation verification, upgrade, repair, rollback, status, and
-ownership-safe uninstall:
+**3. Install the Remote Script** into a Live Control Surface folder
+(dry-run first; refuses symlink trees and overwrites by default):
 
 ```sh
-ableton-mcp-lifecycle install \
-  --remote-scripts-dir '/absolute/path/to/Live/Remote Scripts' \
-  --state-dir '/absolute/owner-only/ableton-mcp' \
-  --package-root '/absolute/installed/package/root' \
-  --artifact '/absolute/path/to/exact-candidate.tgz' \
-  --artifact-sha256 '<exact-tarball-sha>'
+node dist/src/install-remote-script.js --destination '/absolute/path/to/Live/Remote Scripts/AbletonMcpBridge' --dry-run
 ```
 
-Omit `--apply` for a plan. Mutating install/upgrade/rollback/uninstall also
-require `--confirm-live-stopped`; the tool never guesses a Live path, kills
-Live, follows symlink/junction ancestors, deletes drift, or claims activation
-without authenticated `real-live` discovery. See
-[`docs/DELIVERY.md`](docs/DELIVERY.md),
-[`docs/DISTRIBUTION_POLICY.md`](docs/DISTRIBUTION_POLICY.md),
-[`docs/SUPPORT_MATRIX.md`](docs/SUPPORT_MATRIX.md),
-[`docs/CAPABILITY_MATRIX.md`](docs/CAPABILITY_MATRIX.md), and
-[`docs/LIVE_SAFETY.md`](docs/LIVE_SAFETY.md).
+**4. Restart Live, then verify** the authenticated end-to-end path:
 
-Scene audition is a potentially audible workflow. Preview is read-only and
-requires an exact Set name, authoritative stopped/non-recording playback,
-unarmed and non-input-monitored tracks, safe launch quantization, callable
-launch/stop operations, and explicit output-safety evidence. Apply requires
-the returned confirmation and idempotency key, verifies fresh playback, and
-must be stopped with the returned stop confirmation. It is not real-Live
-evidence unless a real authenticated bridge and disposable Set have been
-independently established.
+```sh
+npm run diagnostics -- --config /absolute/path/bridge-config.json
+```
 
-## Capability-aware journeys
+The full mutation sequence, safety model, and client-facing tool reference:
+[`docs/USER_GUIDE.md`](docs/USER_GUIDE.md).
 
-`plan_user_journey`, `ableton://journeys`, and five matching MCP prompts expose
-bounded beat/song, advanced-drum, sound-design, reference-mix, and
-recording/performance-diagnosis plans. Plans negotiate the current epoch,
-capabilities, operations, and provenance; contain no mutation authority; use
-ordered non-color progress text; stop at purpose-specific confirmation gates;
-and include verification, recovery, accessibility, and truthful per-stage
-fallback. Only allowlisted high-level traits influence derived guidance;
-artist/song identity and exact-copy wording is excluded, and a copy-only request
-requires clarification—never an exact-replication or legal-clearance claim. See
-[`docs/USER_JOURNEYS.md`](docs/USER_JOURNEYS.md).
+## What your agent gets
 
-## Audio intelligence
+- **Deep Live control, both views.** Transport, Session clips/scenes/slots,
+  Arrangement clips and locators, MIDI notes (add/update/delete), mixer,
+  Session automation, routing, recording, project info/save/open/backup, and
+  live subscriptions.
+- **Real device mastery.** Recursive discovery of racks, chains, pads, and
+  macros; guarded parameter changes with bounds/quantization checks; Browser
+  search and guarded device loading.
+- **Standards-based audio intelligence — even without Live.** `audio_analyze`
+  returns ITU-R BS.1770-5 / EBU R128 loudness, LRA, and validated true peak
+  (Tech 3341/3342), plus spectral, transient, dynamics, and clipping summaries.
+  `audio_compare_reference` aligns and level-matches your mix against a
+  reference track. PCM is analyzed in an isolated, cancellable worker and raw
+  audio is never returned.
+- **Consent-bound Live audio capture.** When the authenticated bridge reports
+  `real-live`, the agent can resample one exact source clip into an empty slot,
+  analyze it internally, then delete every trace — with a 10-second Live-side
+  watchdog and emergency-stop recovery.
+- **Realtime control.** A separately armed, token-fenced UDP/OSC/XY channel for
+  low-latency parameter rides — with verified writes, replay protection, and an
+  independent TCP emergency stop.
+- **Capability-aware journeys.** `plan_user_journey` (plus MCP prompts and the
+  `ableton://journeys` resource) turns "make a dusty lo-fi beat" into an
+  ordered, confirmable plan — beat/song creation, advanced drums, sound design,
+  reference mixing, or performance diagnosis — that degrades truthfully when a
+  capability isn't negotiated.
 
-`audio_analyze` runs caller PCM in a cancellable secret-stripped worker and
-returns privacy-bounded `pcm-analysis/v2` summaries, including ITU-R BS.1770-5,
-EBU R128/Tech 3341/3342 loudness/LRA and validated 44.1/48 kHz true peak.
-`audio_compare_reference` adds bounded band-limited resampling,
-coarse-to-fine/manual alignment, standards level matching, and aggregate deltas.
-`audio_diagnose_live_context` links measurements to fresh refs without claiming
-that caller PCM came from Live or that an observed device caused a result.
+## Built to never wreck your Set
 
-When—and only when—the installed authenticated bridge reports `real-live` and
-`audio.capture.resampling`, `live_audio_capture_preview/apply` can record one
-exact source through Live's Resampling input into one exact empty audio slot.
-It requires explicit ephemeral consent and output safety, has a ten-second
-Live-side watchdog and post-restart emergency recovery, analyzes a fresh
-bounded WAV internally, deletes the owned clip, and unlinks the WAV/ASD without
-returning raw audio or its path. See
-[`docs/AUDIO_INTELLIGENCE.md`](docs/AUDIO_INTELLIGENCE.md).
+Every mutation follows the same protocol: **fresh discovery → read-only
+preview → exact confirmation → one-use apply → authoritative verification →
+guarded undo.** Idempotency keys, bridge/Live epoch fencing, and an
+execution ledger make retry storms and lost acknowledgements safe to
+reconcile. Arbitrary device or Arrangement-clip deletion is *refused* — the
+server only cleans up what it created, and can prove it. Configuration,
+secrets, and Remote Script installation can never be smuggled in through MCP
+tool arguments. See [`docs/LIVE_SAFETY.md`](docs/LIVE_SAFETY.md).
 
-## Evidence boundary
+## Compatibility
 
-The deterministic simulator, Python fake-Live mapper, package smoke tests,
-benchmarks, and authenticated loopback tests are contract evidence only. They
-do not prove a real Ableton Live version, disposable Set, audio device,
-hardware, accessibility, signing, notarization, or installer-runtime result.
-Tracked evidence distinguishes those contracts from macOS Live 12.4.5b8
-observations through Phase 8; it is not Windows Live, signing, notarization, or
-publication proof. Current limitations are recorded in
-[`docs/IMPLEMENTATION_STATUS.md`](docs/IMPLEMENTATION_STATUS.md), and the
-real-Live safety boundary is in [`docs/LIVE_SAFETY.md`](docs/LIVE_SAFETY.md).
+| Surface | Status |
+|---|---|
+| Node.js 22 / 24 / 25 | Supported (CI-tested) |
+| macOS + Live 12.4.5b8 beta | Verified engineering target (`docs/evidence/`) |
+| macOS + Live 12 Suite / Standard / Intro | Runtime-negotiated; missing content stays unavailable |
+| Windows host | CI-tested; Windows 11 + Live not yet certified |
+| Linux / Live 11 or earlier | Unsupported |
+
+The capability catalog is negotiated at connect time, so your agent always
+knows exactly what this Live installation can do — unsupported shapes report
+as unavailable instead of failing mid-mutation. Full matrix:
+[`docs/SUPPORT_MATRIX.md`](docs/SUPPORT_MATRIX.md).
+
+## Documentation
+
+| Doc | What it covers |
+|---|---|
+| [USER_GUIDE](docs/USER_GUIDE.md) | Tool list, mutation workflow, resources, prompts |
+| [LIVE_SAFETY](docs/LIVE_SAFETY.md) | The real-Live safety boundary |
+| [OPERATIONS](docs/OPERATIONS.md) / [RECOVERY](docs/RECOVERY.md) | Supervision, failure handling, uncertain-state recovery |
+| [AUDIO_INTELLIGENCE](docs/AUDIO_INTELLIGENCE.md) | DSP standards, capture consent, privacy limits |
+| [USER_JOURNEYS](docs/USER_JOURNEYS.md) | The five guided composition workflows |
+| [REALTIME_CONTROL](docs/REALTIME_CONTROL.md) | The armed UDP/OSC/XY control plane |
+| [CAPABILITY_MATRIX](docs/CAPABILITY_MATRIX.md) | Per-tool capability and operation requirements |
+| [DELIVERY](docs/DELIVERY.md) / [DISTRIBUTION_POLICY](docs/DISTRIBUTION_POLICY.md) | Install, upgrade, rollback, and uninstall of packed artifacts |
+| [IMPLEMENTATION_STATUS](docs/IMPLEMENTATION_STATUS.md) | What's verified and what's still limited |
+
+## Development
+
+```sh
+npm test                 # build + unit/integration/property tests
+npm run benchmark        # isolated performance gates
+npm run package:verify   # verify the packed artifact
+```
+
+Open source under the [MIT License](LICENSE.md). Ableton Live is a trademark
+of Ableton AG; this project is not affiliated with or endorsed by Ableton AG.

--- a/README.md
+++ b/README.md
@@ -1,159 +1,77 @@
-# Ableton MCP Beyond
+<p align="center">
+  <img src="docs/assets/logo.svg" width="100" alt="Ableton MCP Beyond logo" />
+</p>
 
-**Give your AI agent real, safety-first control of Ableton Live 12 — Session and
-Arrangement, devices, mixer, browser, recording — plus standards-based audio
-analysis, all over the Model Context Protocol.**
+<h1 align="center">Ableton MCP Beyond</h1>
 
-![Node 22 | 24 | 25](https://img.shields.io/badge/node-22%20%7C%2024%20%7C%2025-339933)
-![MCP 2025-11-25](https://img.shields.io/badge/MCP-2025--11--25-blue)
-![Ableton Live 12](https://img.shields.io/badge/Ableton%20Live-12-5b2ee5)
+<p align="center">
+  Safety-first MCP control of Ableton Live 12 —<br/>
+  76 tools, an authenticated loopback bridge, and standards-based audio analysis.
+</p>
 
-A Node.js MCP host (76 tools, stdio JSON-RPC) that talks to Live through an
-authenticated, HMAC-sealed loopback bridge and a Python Remote Script
-(`AbletonMcpBridge`). Developed and verified against **Live 12.4.5b8 (beta)**.
-Without an explicit bridge configuration it is **fail-closed**: it never reads
-or touches your Set.
+<p align="center">
+  English · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a>
+</p>
 
-## See it work — no Live required
+<p align="center">
+  <a href="https://github.com/user1303836/ableton-mcp-beyond/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/user1303836/ableton-mcp-beyond/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="MIT license" /></a>
+  <a href="apps/mcp-server/package.json"><img src="https://img.shields.io/badge/node-22%20%7C%2024%20%7C%2025-339933?style=flat-square" alt="Node 22 | 24 | 25" /></a>
+  <a href="https://modelcontextprotocol.io/specification/2025-11-25"><img src="https://img.shields.io/badge/MCP-2025--11--25-blue?style=flat-square" alt="MCP protocol 2025-11-25" /></a>
+  <a href="docs/SUPPORT_MATRIX.md"><img src="https://img.shields.io/badge/Ableton%20Live-12-555555?style=flat-square" alt="Ableton Live 12" /></a>
+</p>
+
+---
+
+**An MCP host that never guesses — and never wrecks your Set.**
+
+- **Deep Live control** — transport, Session + Arrangement, clips, MIDI notes, mixer, automation, routing, recording, projects, subscriptions.
+- **Device mastery** — recursive rack/chain/pad/macro discovery, guarded parameter edits, Browser search and load.
+- **Audio intelligence** — ITU-R BS.1770-5 / EBU R128 loudness, validated true peak, reference-mix comparison. Works without Live.
+- **Consent-bound capture** — resample one clip, analyze internally, delete every trace. Watchdog and emergency stop included.
+- **Realtime control** — token-fenced UDP/OSC/XY channel with verified writes and an independent emergency stop.
+- **Guided journeys** — `plan_user_journey` turns "make a lo-fi beat" into an ordered, confirmable, capability-aware plan.
+
+## Quick start
+
+Requires Node.js 22, 24, or 25. Ableton Live 12 for the bridge; the host, tests, and demo run without it.
 
 ```sh
 cd apps/mcp-server
 npm ci && npm run build
-npm run demo
+npm run demo      # a real MCP session, no Live required
+npm test          # full suite
 ```
 
-This drives a real MCP session against the server: handshake, full tool
-catalog, fail-closed status, a live `audio_analyze` run on a synthesized tone,
-and a generated beat-making plan.
-
-<details>
-<summary><b>Actual demo output</b></summary>
-
-```text
-▶ initialize (MCP protocol 2025-11-25)
-  server: {"name":"ableton-mcp-host","version":"1.0.0"}
-
-▶ tools/list
-  tools exposed: 76
-  server_status, capabilities, plan_user_journey, audio_analyze, … live_undo, live_recovery_finalize
-
-▶ server_status + live_status (no Live configured → fail-closed)
-  server_status: {"host":"ready","live":{"connected":false,"adapter":"unavailable", … }}
-  live_status.adapter: "unavailable"
-
-▶ audio_analyze: 2 s 440 Hz sine @ 48 kHz → BS.1770-5 loudness, true peak, spectra
-  peak / rms: "-6.02 dBFS / -9.03 dBFS"
-  BS.1770-5 integrated loudness: "-9.71 LUFS (standardsCompliant: true)"
-  BS.1770-5 Annex 2 true peak: "-6.008 dBTP (ITU-R BS.1770-5 Annex 2 order-48 four-phase FIR)"
-
-▶ plan_user_journey: beat-making plan
-  journey: "create-beat-or-song"
-  stages: ["discover","draft","preview-create","apply-create","arrange",
-           "arrange-edit","audition","revise","final-readback"]
-
-▶ done — no Live instance was read or changed
-```
-
-</details>
-
-## Quick start
-
-**Requirements:** Node.js 22, 24, or 25 (all exercised in CI). Ableton Live 12
-for the bridge; the host, tests, and demo run without it.
+Point your MCP client at the server, and — to control Live — configure the bridge and install the Remote Script:
 
 ```sh
-cd apps/mcp-server
-npm ci
-npm test          # full build + test suite
-npm start         # serve MCP over stdio
-```
-
-**1. Point your MCP client at the server.** Generate a client config:
-
-```sh
-npm run setup -- --output /absolute/path/client-config.json
-```
-
-**2. Connect Live.** Create a strong owner-only secret, then generate a
-bridge configuration:
-
-```sh
-npm run setup -- --output /absolute/path/bridge-config.json \
+npm run setup -- --output /abs/path/client-config.json
+npm run setup -- --output /abs/path/bridge-config.json \
   --bridge-host 127.0.0.1 --bridge-port 9000 \
-  --secret-file /absolute/path/bridge.secret --bridge-timeout 5000
+  --secret-file /abs/path/bridge.secret
+node dist/src/install-remote-script.js --destination '/abs/.../Remote Scripts/AbletonMcpBridge' --dry-run
 ```
 
-**3. Install the Remote Script** into a Live Control Surface folder
-(dry-run first; refuses symlink trees and overwrites by default):
+Restart Live, then verify: `npm run diagnostics -- --config /abs/path/bridge-config.json`.
+Full walkthrough: [docs/USER_GUIDE.md](docs/USER_GUIDE.md).
 
-```sh
-node dist/src/install-remote-script.js --destination '/absolute/path/to/Live/Remote Scripts/AbletonMcpBridge' --dry-run
-```
+## Safety model
 
-**4. Restart Live, then verify** the authenticated end-to-end path:
-
-```sh
-npm run diagnostics -- --config /absolute/path/bridge-config.json
-```
-
-The full mutation sequence, safety model, and client-facing tool reference:
-[`docs/USER_GUIDE.md`](docs/USER_GUIDE.md).
-
-## What your agent gets
-
-- **Deep Live control, both views.** Transport, Session clips/scenes/slots,
-  Arrangement clips and locators, MIDI notes (add/update/delete), mixer,
-  Session automation, routing, recording, project info/save/open/backup, and
-  live subscriptions.
-- **Real device mastery.** Recursive discovery of racks, chains, pads, and
-  macros; guarded parameter changes with bounds/quantization checks; Browser
-  search and guarded device loading.
-- **Standards-based audio intelligence — even without Live.** `audio_analyze`
-  returns ITU-R BS.1770-5 / EBU R128 loudness, LRA, and validated true peak
-  (Tech 3341/3342), plus spectral, transient, dynamics, and clipping summaries.
-  `audio_compare_reference` aligns and level-matches your mix against a
-  reference track. PCM is analyzed in an isolated, cancellable worker and raw
-  audio is never returned.
-- **Consent-bound Live audio capture.** When the authenticated bridge reports
-  `real-live`, the agent can resample one exact source clip into an empty slot,
-  analyze it internally, then delete every trace — with a 10-second Live-side
-  watchdog and emergency-stop recovery.
-- **Realtime control.** A separately armed, token-fenced UDP/OSC/XY channel for
-  low-latency parameter rides — with verified writes, replay protection, and an
-  independent TCP emergency stop.
-- **Capability-aware journeys.** `plan_user_journey` (plus MCP prompts and the
-  `ableton://journeys` resource) turns "make a dusty lo-fi beat" into an
-  ordered, confirmable plan — beat/song creation, advanced drums, sound design,
-  reference mixing, or performance diagnosis — that degrades truthfully when a
-  capability isn't negotiated.
-
-## Built to never wreck your Set
-
-Every mutation follows the same protocol: **fresh discovery → read-only
-preview → exact confirmation → one-use apply → authoritative verification →
-guarded undo.** Idempotency keys, bridge/Live epoch fencing, and an
-execution ledger make retry storms and lost acknowledgements safe to
-reconcile. Arbitrary device or Arrangement-clip deletion is *refused* — the
-server only cleans up what it created, and can prove it. Configuration,
-secrets, and Remote Script installation can never be smuggled in through MCP
-tool arguments. See [`docs/LIVE_SAFETY.md`](docs/LIVE_SAFETY.md).
+Every mutation follows **discover → preview → confirm → apply → verify → undo**. Idempotency keys, epoch fencing, and an execution ledger make lost acknowledgements safe to reconcile; arbitrary deletes are refused. Without an explicit bridge config the server is fail-closed — it cannot read or touch Live. See [docs/LIVE_SAFETY.md](docs/LIVE_SAFETY.md).
 
 ## Compatibility
 
 | Surface | Status |
 |---|---|
 | Node.js 22 / 24 / 25 | Supported (CI-tested) |
-| macOS + Live 12.4.5b8 beta | Verified engineering target (`docs/evidence/`) |
-| macOS + Live 12 Suite / Standard / Intro | Runtime-negotiated; missing content stays unavailable |
+| macOS + Live 12 | Verified against 12.4.5b8 beta ([evidence](docs/evidence/)) |
 | Windows host | CI-tested; Windows 11 + Live not yet certified |
 | Linux / Live 11 or earlier | Unsupported |
 
-The capability catalog is negotiated at connect time, so your agent always
-knows exactly what this Live installation can do — unsupported shapes report
-as unavailable instead of failing mid-mutation. Full matrix:
-[`docs/SUPPORT_MATRIX.md`](docs/SUPPORT_MATRIX.md).
+Capabilities are negotiated at connect time, so your agent always knows exactly what a given Live install can do. Full matrix: [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md).
 
-## Documentation
+## Docs
 
 | Doc | What it covers |
 |---|---|
@@ -164,16 +82,9 @@ as unavailable instead of failing mid-mutation. Full matrix:
 | [USER_JOURNEYS](docs/USER_JOURNEYS.md) | The five guided composition workflows |
 | [REALTIME_CONTROL](docs/REALTIME_CONTROL.md) | The armed UDP/OSC/XY control plane |
 | [CAPABILITY_MATRIX](docs/CAPABILITY_MATRIX.md) | Per-tool capability and operation requirements |
-| [DELIVERY](docs/DELIVERY.md) / [DISTRIBUTION_POLICY](docs/DISTRIBUTION_POLICY.md) | Install, upgrade, rollback, and uninstall of packed artifacts |
+| [DELIVERY](docs/DELIVERY.md) | Install, upgrade, rollback, uninstall of packed artifacts |
 | [IMPLEMENTATION_STATUS](docs/IMPLEMENTATION_STATUS.md) | What's verified and what's still limited |
 
-## Development
+## License
 
-```sh
-npm test                 # build + unit/integration/property tests
-npm run benchmark        # isolated performance gates
-npm run package:verify   # verify the packed artifact
-```
-
-Open source under the [MIT License](LICENSE.md). Ableton Live is a trademark
-of Ableton AG; this project is not affiliated with or endorsed by Ableton AG.
+Open source under the [MIT License](LICENSE.md). Ableton Live is a trademark of Ableton AG; this project is not affiliated with or endorsed by Ableton AG.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,92 @@
+<p align="center">
+  <img src="docs/assets/logo.svg" width="100" alt="Ableton MCP Beyond 标志" />
+</p>
+
+<h1 align="center">Ableton MCP Beyond</h1>
+
+<p align="center">
+  以安全为先的 Ableton Live 12 MCP 控制 ——<br/>
+  76 个工具、经认证的本地回环桥接,以及基于标准的音频分析。
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> · 简体中文 · <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/user1303836/ableton-mcp-beyond/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/user1303836/ableton-mcp-beyond/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="MIT 许可证" /></a>
+  <a href="apps/mcp-server/package.json"><img src="https://img.shields.io/badge/node-22%20%7C%2024%20%7C%2025-339933?style=flat-square" alt="Node 22 | 24 | 25" /></a>
+  <a href="https://modelcontextprotocol.io/specification/2025-11-25"><img src="https://img.shields.io/badge/MCP-2025--11--25-blue?style=flat-square" alt="MCP 协议 2025-11-25" /></a>
+  <a href="docs/SUPPORT_MATRIX.md"><img src="https://img.shields.io/badge/Ableton%20Live-12-555555?style=flat-square" alt="Ableton Live 12" /></a>
+</p>
+
+---
+
+**一个绝不臆测、也绝不毁掉您工程(Set)的 MCP 宿主。**
+
+- **深度 Live 控制** —— 走带、Session 与 Arrangement、剪辑、MIDI 音符、混音器、自动化、路由、录音、工程、订阅。
+- **设备精通** —— 递归发现 rack/chain/pad/macro,受护栏约束的参数编辑,Browser 搜索与加载。
+- **音频智能** —— ITU-R BS.1770-5 / EBU R128 响度、经验证的真峰值、参考曲目混音对比。无需 Live 即可使用。
+- **知情同意的音频捕获** —— 重采样单个剪辑、内部分析、删除所有痕迹。内置看门狗与紧急停止。
+- **实时控制** —— 令牌隔离的 UDP/OSC/XY 通道,写入经校验,并配有独立的紧急停止。
+- **引导式旅程** —— `plan_user_journey` 将“做一段 lo-fi 节拍”变成有序、可确认、感知当前能力的计划。
+
+## 快速上手
+
+需要 Node.js 22、24 或 25。桥接需要 Ableton Live 12;宿主、测试与演示无需 Live 即可运行。
+
+```sh
+cd apps/mcp-server
+npm ci && npm run build
+npm run demo      # 真实的 MCP 会话,无需 Live
+npm test          # 完整测试套件
+```
+
+将您的 MCP 客户端指向服务器;如需控制 Live,请配置桥接并安装 Remote Script:
+
+```sh
+npm run setup -- --output /abs/path/client-config.json
+npm run setup -- --output /abs/path/bridge-config.json \
+  --bridge-host 127.0.0.1 --bridge-port 9000 \
+  --secret-file /abs/path/bridge.secret
+node dist/src/install-remote-script.js --destination '/abs/.../Remote Scripts/AbletonMcpBridge' --dry-run
+```
+
+重启 Live,然后验证:`npm run diagnostics -- --config /abs/path/bridge-config.json`。
+完整教程:[docs/USER_GUIDE.md](docs/USER_GUIDE.md)(英文)。
+
+## 安全模型
+
+每项变更都遵循 **发现 → 预览 → 确认 → 应用 → 验证 → 撤销** 的流程。幂等键、epoch 隔离与执行账本,使丢失的确认也能安全地对账;任意删除一律被拒绝。未经显式桥接配置,服务器处于故障关闭状态 —— 无法读取或改动 Live。参见 [docs/LIVE_SAFETY.md](docs/LIVE_SAFETY.md)(英文)。
+
+## 兼容性
+
+| 平台 | 状态 |
+|---|---|
+| Node.js 22 / 24 / 25 | 支持(CI 测试) |
+| macOS + Live 12 | 已对 12.4.5b8 beta 验证([证据](docs/evidence/)) |
+| Windows 宿主 | 已通过 CI;Windows 11 + Live 尚未认证 |
+| Linux / Live 11 或更早 | 不支持 |
+
+能力在连接时协商确定,您的代理始终清楚当前 Live 安装能做什么。完整矩阵:[docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md)(英文)。
+
+## 文档
+
+以下文档均为英文。
+
+| 文档 | 内容 |
+|---|---|
+| [USER_GUIDE](docs/USER_GUIDE.md) | 工具列表、变更工作流、资源与提示词 |
+| [LIVE_SAFETY](docs/LIVE_SAFETY.md) | 真实 Live 的安全边界 |
+| [OPERATIONS](docs/OPERATIONS.md) / [RECOVERY](docs/RECOVERY.md) | 运行监督、故障处理、不确定状态恢复 |
+| [AUDIO_INTELLIGENCE](docs/AUDIO_INTELLIGENCE.md) | DSP 标准、捕获同意、隐私限制 |
+| [USER_JOURNEYS](docs/USER_JOURNEYS.md) | 五个引导式创作工作流 |
+| [REALTIME_CONTROL](docs/REALTIME_CONTROL.md) | 已布防的 UDP/OSC/XY 控制平面 |
+| [CAPABILITY_MATRIX](docs/CAPABILITY_MATRIX.md) | 每个工具的能力与操作要求 |
+| [DELIVERY](docs/DELIVERY.md) | 打包产物的安装、升级、回滚与卸载 |
+| [IMPLEMENTATION_STATUS](docs/IMPLEMENTATION_STATUS.md) | 已验证内容与当前限制 |
+
+## 许可证
+
+基于 [MIT 许可证](LICENSE.md)开源。Ableton Live 是 Ableton AG 的商标;本项目与 Ableton AG 无关联,亦未获其认可。

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -37,6 +37,7 @@
     "migrate": "node dist/src/migrate.js",
     "diagnostics": "node dist/src/diagnostics.js",
     "start": "node dist/src/cli.js",
+    "demo": "node scripts/demo.mjs",
     "prepack": "npm run build && node scripts/stage-remote-script.mjs && node scripts/stage-release-artifact.mjs"
   },
   "devDependencies": {

--- a/apps/mcp-server/scripts/demo.mjs
+++ b/apps/mcp-server/scripts/demo.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Zero-config MCP demo: drives dist/src/cli.js over stdio with the default
+// fail-closed adapter (no Ableton Live required). Run `npm run build` first.
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const cli = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../dist/src/cli.js");
+
+// --- synthesize 2 s of a 440 Hz sine at 48 kHz (mono float32 LE) ---
+const sr = 48000;
+const n = sr * 2;
+const buf = Buffer.alloc(n * 4);
+for (let i = 0; i < n; i++) buf.writeFloatLE(0.5 * Math.sin((2 * Math.PI * 440 * i) / sr), i * 4);
+const pcmBase64 = buf.toString("base64");
+
+const server = spawn(process.execPath, [cli], { stdio: ["pipe", "pipe", "inherit"] });
+let nextId = 1;
+const pending = new Map();
+let lineBuf = "";
+
+server.stdout.on("data", (chunk) => {
+  lineBuf += chunk;
+  let idx;
+  while ((idx = lineBuf.indexOf("\n")) !== -1) {
+    const line = lineBuf.slice(0, idx).trim();
+    lineBuf = lineBuf.slice(idx + 1);
+    if (!line) continue;
+    const msg = JSON.parse(line);
+    if (msg.id !== undefined && pending.has(msg.id)) {
+      pending.get(msg.id)(msg);
+      pending.delete(msg.id);
+    }
+  }
+});
+
+const send = (msg) => server.stdin.write(JSON.stringify(msg) + "\n");
+const request = (method, params) =>
+  new Promise((resolve) => {
+    const id = nextId++;
+    pending.set(id, resolve);
+    send({ jsonrpc: "2.0", id, method, params });
+  });
+const callTool = (name, args) => request("tools/call", { name, arguments: args });
+const toolJson = (res) => JSON.parse(res.result.content[0].text);
+
+const step = (title) => console.log(`\n\x1b[1m▶ ${title}\x1b[0m`);
+const show = (label, obj) => console.log(`  ${label}:`, JSON.stringify(obj));
+
+// --- 1. handshake -----------------------------------------------------------
+step("initialize (MCP protocol 2025-11-25)");
+const init = await request("initialize", {
+  protocolVersion: "2025-11-25",
+  capabilities: {},
+  clientInfo: { name: "demo", version: "1.0.0" },
+});
+show("server", init.result.serverInfo);
+send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+// --- 2. tool catalog --------------------------------------------------------
+step("tools/list");
+const tools = (await request("tools/list", {})).result.tools;
+show("tools exposed", tools.length);
+console.log("  " + tools.map((t) => t.name).join(", "));
+
+// --- 3. status without Live (fail-closed) -----------------------------------
+step("server_status + live_status (no Live configured → fail-closed)");
+show("server_status", toolJson(await callTool("server_status", {})));
+show("live_status.adapter", toolJson(await callTool("live_status", {})).adapter);
+
+// --- 4. real audio analysis (no Live needed) --------------------------------
+step("audio_analyze: 2 s 440 Hz sine @ 48 kHz → BS.1770-5 loudness, true peak, spectra");
+const analysis = toolJson(await callTool("audio_analyze", { pcmBase64, sampleRate: sr, channels: 1 }));
+const bs1770 = analysis.standardsAudio;
+show("peak / rms", `${analysis.peakDbfs.toFixed(2)} dBFS / ${analysis.rmsDbfs.toFixed(2)} dBFS`);
+show("BS.1770-5 integrated loudness", `${bs1770.loudness.integratedLufs.toFixed(2)} LUFS (standardsCompliant: ${bs1770.loudness.standardsCompliant})`);
+show("BS.1770-5 Annex 2 true peak", `${bs1770.truePeak.aggregateDbtp.toFixed(3)} dBTP (${bs1770.truePeak.method})`);
+
+// --- 5. capability-aware journey plan ---------------------------------------
+step("plan_user_journey: beat-making plan");
+const plan = toolJson(
+  await callTool("plan_user_journey", { journey: "create-beat-or-song", traits: "dusty lo-fi hip hop groove", experienceLevel: "beginner", bars: 4 }),
+);
+show("journey", plan.journey ?? plan.id);
+show("stages", Array.isArray(plan.stages) ? plan.stages.map((s) => s.id ?? s.title) : "(see full output)");
+
+step("done — no Live instance was read or changed");
+server.kill();

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <!-- 3x3 Session clip grid -->
+  <g fill="#666666">
+    <rect x="2"    y="2"    width="17" height="17" opacity="0.35"/>
+    <rect x="23.5" y="2"    width="17" height="17" opacity="0.35"/>
+    <rect x="45"   y="2"    width="17" height="17" opacity="0.35"/>
+    <rect x="2"    y="23.5" width="17" height="17" opacity="0.35"/>
+    <rect x="45"   y="23.5" width="17" height="17" opacity="0.35"/>
+    <rect x="2"    y="45"   width="17" height="17" opacity="0.7"/>
+    <rect x="23.5" y="45"   width="17" height="17" opacity="0.7"/>
+    <rect x="45"   y="45"   width="17" height="17" opacity="0.7"/>
+    <!-- launching clip -->
+    <rect x="23.5" y="23.5" width="17" height="17"/>
+  </g>
+  <path d="M27.5 26.5v11l10-5.5z" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## What

A full README refresh: centered header with a simple logo, minimal body, Chinese/Japanese READMEs, a **runnable demo**, and the **MIT license** switch discussed in review.

### Structure (`README.md`, rewritten)
- **Centered header**: simple SVG logo (a 3×3 Session clip grid with one launching clip), one-line tagline, language links (**English · 简体中文 · 日本語**), flat-square badges (MIT / Node / MCP protocol / Live 12).
- **Six one-line feature bullets**: deep Live control, device mastery, audio intelligence, consent-bound capture, realtime UDP/OSC/XY, guided journeys.
- **Quick start** compressed to two command blocks (build/demo/test → client+bridge config + Remote Script install + diagnostics).
- **Safety model** in two sentences. **Compatibility table** and **docs map** at the bottom (honest about macOS-verified vs Windows-not-yet-certified).

### Runnable demo (`apps/mcp-server/scripts/demo.mjs`, new; `npm run demo`)
Drives a **real MCP session** over stdio against the packaged server — initialize handshake, `tools/list` (all 76 tools), fail-closed `server_status`/`live_status`, a genuine `audio_analyze` run on a synthesized 440 Hz tone (−9.71 LUFS integrated, −6.008 dBTP true peak via BS.1770-5 Annex 2), and a `plan_user_journey` beat-making plan. Requires no Ableton install; touches no Live state. A narrated agent-drives-Live demo video will be added separately.

### i18n
`README.zh-CN.md` and `README.ja.md` mirror the English README (code, tool names, and doc links unchanged; docs noted as English-only).

### License (`LICENSE.md`)
Replaced the "Private distribution notice / all rights reserved" with **MIT**, plus an Ableton trademark non-affiliation note. **Please confirm MIT is the license you want** — happy to swap for Apache-2.0 etc. in one commit.

## Intentionally NOT in this PR
The release pipeline still encodes the old private-channel policy: `package.json` (`"private": true`, `"license": "UNLICENSED"`), `src/lifecycle.ts` + `scripts/verify-package.mjs` enforce it, `release-manifest.json` labels `LICENSE.md` as `private-license`, and `docs/DISTRIBUTION_POLICY.md` documents private-tarball-only distribution. That's code-and-test-entangled, so it deserves its own PR (this branch is CI-safe regardless: `prepack` re-stages `LICENSE.md` and regenerates the manifest at pack time).

## Verification
- `npm test`: **231 pass / 0 fail**
- `npm run demo`: runs a real MCP session end to end; no Ableton required
